### PR TITLE
Add explicit access token invalidation

### DIFF
--- a/Heimdall/Heimdall.swift
+++ b/Heimdall/Heimdall.swift
@@ -56,6 +56,14 @@ public class Heimdall {
         self.httpClient = httpClient
     }
 
+    /// Invalidates the currently stored access token, if any.
+    ///
+    /// **Note:** Sets the access token's expiration date to
+    ///     1 January 1970, GMT.
+    public func invalidateAccessToken() {
+        accessToken = accessToken?.copy(expiresAt: NSDate(timeIntervalSince1970: 0))
+    }
+
     /// Requests an access token with the resource owner's password credentials.
     ///
     /// **Note:** The completion closure may be invoked on any thread.

--- a/Heimdall/OAuthAccessToken.swift
+++ b/Heimdall/OAuthAccessToken.swift
@@ -32,6 +32,22 @@ public class OAuthAccessToken {
         self.expiresAt = expiresAt
         self.refreshToken = refreshToken
     }
+
+    /// Copies the access token, using new values if provided.
+    ///
+    /// :param: accessToken The new access token.
+    /// :param: tokenType The new access token's type.
+    /// :param: expiresAt The new access token's expiration date.
+    /// :param: refreshToken The new refresh token.
+    ///
+    /// :returns: A new access token with this access token's values for
+    ///     properties where new ones are not provided.
+    public func copy(accessToken: String? = nil, tokenType: String? = nil, expiresAt: NSDate?? = nil, refreshToken: String?? = nil) -> OAuthAccessToken {
+        return OAuthAccessToken(accessToken: accessToken ?? self.accessToken,
+                                  tokenType: tokenType ?? self.tokenType,
+                                  expiresAt: expiresAt ?? self.expiresAt,
+                               refreshToken: refreshToken ?? self.refreshToken)
+    }
 }
 
 extension OAuthAccessToken: Equatable {}

--- a/HeimdallTests/HeimdallSpec.swift
+++ b/HeimdallTests/HeimdallSpec.swift
@@ -10,7 +10,7 @@ class OAuthAccessTokenMockStore: OAuthAccessTokenStore {
     var mockedAccessToken: OAuthAccessToken? = nil
     var storedAccessToken: OAuthAccessToken? = nil
     
-    func storeAccessToken(accessToken: OAuthAccessToken?){
+    func storeAccessToken(accessToken: OAuthAccessToken?) {
         storeAccessTokenCalled = true
 
         storedAccessToken = accessToken
@@ -42,6 +42,18 @@ class HeimdallSpec: QuickSpec {
                     accessTokenStore.mockedAccessToken = OAuthAccessToken(accessToken: "foo", tokenType: "bar")
                     expect(heimdall.hasAccessToken).to(beTrue())
                 }
+            }
+        }
+
+        describe("-invalidateAccessToken") {
+            beforeEach {
+                accessTokenStore.storeAccessToken(OAuthAccessToken(accessToken: "foo", tokenType: "bar", expiresAt: NSDate(timeIntervalSinceNow: 3600)))
+            }
+
+            it("invalidates the currently stored access token") {
+                heimdall.invalidateAccessToken()
+
+                expect(accessTokenStore.retrieveAccessToken()?.expiresAt).to(equal(NSDate(timeIntervalSince1970: 0)))
             }
         }
 

--- a/HeimdallTests/OAuthAccessTokenSpec.swift
+++ b/HeimdallTests/OAuthAccessTokenSpec.swift
@@ -5,6 +5,99 @@ import Quick
 
 class OAuthAccessTokenSpec: QuickSpec {
     override func spec() {
+        describe("-copy") {
+            let accessToken = OAuthAccessToken(accessToken: "accessToken",
+                                                 tokenType: "tokenType",
+                                                 expiresAt: NSDate(timeIntervalSince1970: 0),
+                                              refreshToken: "refreshToken")
+
+            it("returns a copy of an access token") {
+                let result = accessToken.copy()
+
+                expect(result).toNot(beIdenticalTo(accessToken))
+            }
+
+            context("when providing a new access token") {
+                let result = accessToken.copy(accessToken: "accessToken2")
+
+                it("sets the provided access token on the new access token") {
+                    expect(result.accessToken).to(equal("accessToken2"))
+                }
+
+                it("sets the original token type on the new access token") {
+                    expect(result.tokenType).to(equal(accessToken.tokenType))
+                }
+
+                it("sets the original expiration date on the new access token") {
+                    expect(result.expiresAt).to(equal(accessToken.expiresAt))
+                }
+
+                it("sets the original refreh token on the new access token") {
+                    expect(result.refreshToken).to(equal(accessToken.refreshToken))
+                }
+            }
+
+            context("when providing a new token type") {
+                let result = accessToken.copy(tokenType: "tokenType2")
+
+                it("sets the original access token on the new access token") {
+                    expect(result.accessToken).to(equal(accessToken.accessToken))
+                }
+
+                it("sets the provided token type on the new access token") {
+                    expect(result.tokenType).to(equal("tokenType2"))
+                }
+
+                it("sets the original expiration date on the new access token") {
+                    expect(result.expiresAt).to(equal(accessToken.expiresAt))
+                }
+
+                it("sets the original refreh token on the new access token") {
+                    expect(result.refreshToken).to(equal(accessToken.refreshToken))
+                }
+            }
+
+            context("when providing a new expiration date") {
+                let result = accessToken.copy(expiresAt: NSDate(timeIntervalSince1970: 1))
+
+                it("sets the original access token on the new access token") {
+                    expect(result.accessToken).to(equal(accessToken.accessToken))
+                }
+
+                it("sets the original token type on the new access token") {
+                    expect(result.tokenType).to(equal(accessToken.tokenType))
+                }
+
+                it("sets the provided expiration date on the new access token") {
+                    expect(result.expiresAt).to(equal(NSDate(timeIntervalSince1970: 1)))
+                }
+
+                it("sets the original refreh token on the new access token") {
+                    expect(result.refreshToken).to(equal(accessToken.refreshToken))
+                }
+            }
+
+            context("when providing a new refresh token") {
+                let result = accessToken.copy(refreshToken: "refreshToken2")
+
+                it("sets the original access token on the new access token") {
+                    expect(result.accessToken).to(equal(accessToken.accessToken))
+                }
+
+                it("sets the original token type on the new access token") {
+                    expect(result.tokenType).to(equal(accessToken.tokenType))
+                }
+
+                it("sets the original expiration date on the new access token") {
+                    expect(result.expiresAt).to(equal(accessToken.expiresAt))
+                }
+
+                it("sets the provided refresh token on the new access token") {
+                    expect(result.refreshToken).to(equal("refreshToken2"))
+                }
+            }
+        }
+
         describe("<Equatable> ==") {
             it("returns true if access tokens are equal") {
                 let lhs = OAuthAccessToken(accessToken: "accessToken", tokenType: "tokenType")


### PR DESCRIPTION
An access token is invalidated by setting its expiration date to 1 January 1970, GMT.

Closes #40.