### PR TITLE
Add Makefile task to create a carthage archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+archive:
+	carthage build --no-skip-current --platform iOS
+	carthage archive Heimdall


### PR DESCRIPTION
`make archive` creates a zip file that can be attached to GitHub releases