### PR TITLE
Use OHHTTPStubs instead of aerogear-ios-httpstub

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "Quick/Quick" ~> 0.2
 github "Quick/Nimble" ~> 0.3
-github "aerogear/aerogear-ios-httpstub" ~> 0.2
+github "AliSoftware/OHHTTPStubs" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,7 +1,7 @@
 github "kishikawakatsumi/KeychainAccess" "v1.1.3"
 github "LlamaKit/LlamaKit" "v0.5.0"
 github "Quick/Nimble" "v0.3.1"
+github "AliSoftware/OHHTTPStubs" "8f0f04866a2ffa1309527dd228151bba68b7fbae"
 github "Quick/Quick" "v0.2.2"
-github "aerogear/aerogear-ios-httpstub" "0.2.0"
 github "thoughtbot/runes" "v1.1.1"
 github "thoughtbot/Argo" "v0.3.4"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,6 +1,6 @@
 github "kishikawakatsumi/KeychainAccess" "v1.1.3"
 github "LlamaKit/LlamaKit" "v0.5.0"
-github "Quick/Nimble" "v0.3.0"
+github "Quick/Nimble" "v0.3.1"
 github "Quick/Quick" "v0.2.2"
 github "aerogear/aerogear-ios-httpstub" "0.2.0"
 github "thoughtbot/runes" "v1.1.1"

--- a/Heimdall.xcodeproj/project.pbxproj
+++ b/Heimdall.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		227ADD371A9347E000F3831E /* HeimdallHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227ADD361A9347E000F3831E /* HeimdallHTTPClient.swift */; };
 		227ADD391A93487F00F3831E /* HeimdallHTTPClientNSURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227ADD381A93487F00F3831E /* HeimdallHTTPClientNSURLSession.swift */; };
+		22B8F4811AAEFA62004C1641 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 22B8F4801AAEFA62004C1641 /* OHHTTPStubs.framework */; };
 		22BC44611A8A3FBA00AB0A14 /* OAuthAccessTokenKeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC44601A8A3FBA00AB0A14 /* OAuthAccessTokenKeychainStore.swift */; };
 		22BC44631A8A402300AB0A14 /* OAuthAccessTokenKeychainStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC44621A8A402300AB0A14 /* OAuthAccessTokenKeychainStoreSpec.swift */; };
 		22BC446C1A8B858D00AB0A14 /* OAuthAccessTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC446B1A8B858D00AB0A14 /* OAuthAccessTokenStore.swift */; };
@@ -16,7 +17,6 @@
 		DC336D5D1A938E5D002AE918 /* Argo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC336D591A938E5D002AE918 /* Argo.framework */; };
 		DC336D5E1A938E5D002AE918 /* KeychainAccess.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC336D5A1A938E5D002AE918 /* KeychainAccess.framework */; };
 		DC336D5F1A938E5D002AE918 /* LlamaKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC336D5B1A938E5D002AE918 /* LlamaKit.framework */; };
-		DC336D641A938F13002AE918 /* AeroGearHttpStub.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC336D611A938F13002AE918 /* AeroGearHttpStub.framework */; };
 		DC336D651A938F13002AE918 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC336D621A938F13002AE918 /* Nimble.framework */; };
 		DC336D661A938F13002AE918 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC336D631A938F13002AE918 /* Quick.framework */; };
 		DC545DC81A89F0F10051A575 /* Heimdall.h in Headers */ = {isa = PBXBuildFile; fileRef = DC545DC71A89F0F10051A575 /* Heimdall.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -56,6 +56,7 @@
 /* Begin PBXFileReference section */
 		227ADD361A9347E000F3831E /* HeimdallHTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeimdallHTTPClient.swift; sourceTree = "<group>"; };
 		227ADD381A93487F00F3831E /* HeimdallHTTPClientNSURLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeimdallHTTPClientNSURLSession.swift; sourceTree = "<group>"; };
+		22B8F4801AAEFA62004C1641 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		22BC44601A8A3FBA00AB0A14 /* OAuthAccessTokenKeychainStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthAccessTokenKeychainStore.swift; sourceTree = "<group>"; };
 		22BC44621A8A402300AB0A14 /* OAuthAccessTokenKeychainStoreSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthAccessTokenKeychainStoreSpec.swift; sourceTree = "<group>"; };
 		22BC446B1A8B858D00AB0A14 /* OAuthAccessTokenStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthAccessTokenStore.swift; sourceTree = "<group>"; };
@@ -63,7 +64,6 @@
 		DC336D591A938E5D002AE918 /* Argo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Argo.framework; path = Carthage/Build/iOS/Argo.framework; sourceTree = "<group>"; };
 		DC336D5A1A938E5D002AE918 /* KeychainAccess.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KeychainAccess.framework; path = Carthage/Build/iOS/KeychainAccess.framework; sourceTree = "<group>"; };
 		DC336D5B1A938E5D002AE918 /* LlamaKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LlamaKit.framework; path = Carthage/Build/iOS/LlamaKit.framework; sourceTree = "<group>"; };
-		DC336D611A938F13002AE918 /* AeroGearHttpStub.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AeroGearHttpStub.framework; path = Carthage/Build/iOS/AeroGearHttpStub.framework; sourceTree = "<group>"; };
 		DC336D621A938F13002AE918 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		DC336D631A938F13002AE918 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		DC545DC21A89F0F10051A575 /* Heimdall.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Heimdall.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -108,9 +108,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				22B8F4811AAEFA62004C1641 /* OHHTTPStubs.framework in Frameworks */,
 				DC336D651A938F13002AE918 /* Nimble.framework in Frameworks */,
 				DC336D661A938F13002AE918 /* Quick.framework in Frameworks */,
-				DC336D641A938F13002AE918 /* AeroGearHttpStub.framework in Frameworks */,
 				DC545DCE1A89F0F10051A575 /* Heimdall.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -132,9 +132,9 @@
 		DC336D681A93A776002AE918 /* Private */ = {
 			isa = PBXGroup;
 			children = (
+				22B8F4801AAEFA62004C1641 /* OHHTTPStubs.framework */,
 				DC336D631A938F13002AE918 /* Quick.framework */,
 				DC336D621A938F13002AE918 /* Nimble.framework */,
-				DC336D611A938F13002AE918 /* AeroGearHttpStub.framework */,
 			);
 			name = Private;
 			sourceTree = "<group>";
@@ -358,7 +358,7 @@
 				"$(SRCROOT)/Carthage/Build/iOS/Runes.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Argo.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/KeychainAccess.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/AeroGearHttpStub.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/OHHTTPStubs.framework",
 			);
 			outputPaths = (
 			);
@@ -544,6 +544,7 @@
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -562,6 +563,7 @@
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				INFOPLIST_FILE = HeimdallTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Heimdall.xcodeproj/project.pbxproj
+++ b/Heimdall.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		DCA5B99F1A8A455700667D32 /* request-invalid-norefresh.json in Resources */ = {isa = PBXBuildFile; fileRef = DCA5B99D1A8A455700667D32 /* request-invalid-norefresh.json */; };
 		DCA5B9A01A8A455700667D32 /* request-valid.json in Resources */ = {isa = PBXBuildFile; fileRef = DCA5B99E1A8A455700667D32 /* request-valid.json */; };
 		DCA5B9A21A8A4A8C00667D32 /* request-invalid.json in Resources */ = {isa = PBXBuildFile; fileRef = DCA5B9A11A8A4A8C00667D32 /* request-invalid.json */; };
-		DCA5B9A51A8A565C00667D32 /* StubResponseExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCA5B9A41A8A565C00667D32 /* StubResponseExtensions.swift */; };
 		DCB2540D1A8CF70D00226966 /* OAuthAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB2540C1A8CF70D00226966 /* OAuthAccessToken.swift */; };
 		DCB2540F1A8CF74B00226966 /* OAuthAccessTokenSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB2540E1A8CF74B00226966 /* OAuthAccessTokenSpec.swift */; };
 		DCB254111A8D010800226966 /* OAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCB254101A8D010800226966 /* OAuthError.swift */; };
@@ -84,7 +83,6 @@
 		DCA5B99D1A8A455700667D32 /* request-invalid-norefresh.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "request-invalid-norefresh.json"; sourceTree = "<group>"; };
 		DCA5B99E1A8A455700667D32 /* request-valid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "request-valid.json"; sourceTree = "<group>"; };
 		DCA5B9A11A8A4A8C00667D32 /* request-invalid.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "request-invalid.json"; sourceTree = "<group>"; };
-		DCA5B9A41A8A565C00667D32 /* StubResponseExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StubResponseExtensions.swift; sourceTree = "<group>"; };
 		DCB2540C1A8CF70D00226966 /* OAuthAccessToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthAccessToken.swift; sourceTree = "<group>"; };
 		DCB2540E1A8CF74B00226966 /* OAuthAccessTokenSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthAccessTokenSpec.swift; sourceTree = "<group>"; };
 		DCB254101A8D010800226966 /* OAuthError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthError.swift; sourceTree = "<group>"; };
@@ -228,7 +226,6 @@
 		DCD72CAD1A8B9ED90024BAC1 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				DCA5B9A41A8A565C00667D32 /* StubResponseExtensions.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -392,7 +389,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				DCB2540F1A8CF74B00226966 /* OAuthAccessTokenSpec.swift in Sources */,
-				DCA5B9A51A8A565C00667D32 /* StubResponseExtensions.swift in Sources */,
 				22BC44631A8A402300AB0A14 /* OAuthAccessTokenKeychainStoreSpec.swift in Sources */,
 				DCD72CB71A8CABB20024BAC1 /* NSURLRequestExtensionsSpec.swift in Sources */,
 				DCA5B9911A8A2B9700667D32 /* HeimdallSpec.swift in Sources */,

--- a/HeimdallTests/HeimdallSpec.swift
+++ b/HeimdallTests/HeimdallSpec.swift
@@ -88,7 +88,7 @@ class HeimdallSpec: QuickSpec {
                     OHHTTPStubs.stubRequestsPassingTest({ request in
                         return (request.URL.absoluteString! == "http://rheinfabrik.de")
                     }, withStubResponse: { request in
-                        return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("authorize-valid", ofType: "json")!), statusCode: 200, headers: nil)
+                        return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("authorize-valid", ofType: "json")!), statusCode: 200, headers: [ "Content-Type": "application/json" ])
                     })
 
                     waitUntil { done in
@@ -156,7 +156,7 @@ class HeimdallSpec: QuickSpec {
                     OHHTTPStubs.stubRequestsPassingTest({ request in
                         return (request.URL.absoluteString! == "http://rheinfabrik.de")
                         }, withStubResponse: { request in
-                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("authorize-invalid", ofType: "json")!), statusCode: 200, headers: nil)
+                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("authorize-invalid", ofType: "json")!), statusCode: 200, headers: [ "Content-Type": "application/json" ])
                     })
 
                     waitUntil { done in
@@ -191,7 +191,7 @@ class HeimdallSpec: QuickSpec {
                     OHHTTPStubs.stubRequestsPassingTest({ request in
                         return (request.URL.absoluteString! == "http://rheinfabrik.de")
                         }, withStubResponse: { request in
-                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("authorize-invalid-token", ofType: "json")!), statusCode: 200, headers: nil)
+                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("authorize-invalid-token", ofType: "json")!), statusCode: 200, headers: [ "Content-Type": "application/json" ])
                     })
 
                     waitUntil { done in
@@ -227,7 +227,7 @@ class HeimdallSpec: QuickSpec {
                     OHHTTPStubs.stubRequestsPassingTest({ request in
                         return (request.URL.absoluteString! == "http://rheinfabrik.de")
                         }, withStubResponse: { request in
-                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("authorize-invalid-type", ofType: "json")!), statusCode: 200, headers: nil)
+                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("authorize-invalid-type", ofType: "json")!), statusCode: 200, headers: [ "Content-Type": "application/json" ])
                     })
 
                     waitUntil { done in
@@ -296,7 +296,7 @@ class HeimdallSpec: QuickSpec {
                     OHHTTPStubs.stubRequestsPassingTest({ request in
                         return (request.URL.absoluteString! == "http://rheinfabrik.de")
                         }, withStubResponse: { request in
-                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("request-valid", ofType: "json")!), statusCode: 200, headers: nil)
+                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("request-valid", ofType: "json")!), statusCode: 200, headers: [ "Content-Type": "application/json" ])
                     })
 
                     waitUntil { done in
@@ -328,7 +328,7 @@ class HeimdallSpec: QuickSpec {
                     OHHTTPStubs.stubRequestsPassingTest({ request in
                         return (request.URL.absoluteString! == "http://rheinfabrik.de")
                         }, withStubResponse: { request in
-                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("request-invalid-norefresh", ofType: "json")!), statusCode: 200, headers: nil)
+                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("request-invalid-norefresh", ofType: "json")!), statusCode: 200, headers: [ "Content-Type": "application/json" ])
                     })
 
                     waitUntil { done in
@@ -367,7 +367,7 @@ class HeimdallSpec: QuickSpec {
                             && heimdall.hasAccessToken == false
                             )
                         }, withStubResponse: { request in
-                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("request-invalid", ofType: "json")!), statusCode: 200, headers: nil)
+                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("request-invalid", ofType: "json")!), statusCode: 200, headers: [ "Content-Type": "application/json" ])
                     })
 
                     waitUntil { done in
@@ -377,7 +377,7 @@ class HeimdallSpec: QuickSpec {
                     OHHTTPStubs.stubRequestsPassingTest({ request in
                         return (request.URL.absoluteString! == "http://rheinfabrik.de")
                         }, withStubResponse: { request in
-                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("request-valid", ofType: "json")!), statusCode: 200, headers: nil)
+                            return OHHTTPStubsResponse(data: NSData(contentsOfFile: self.bundle.pathForResource("request-valid", ofType: "json")!), statusCode: 200, headers: [ "Content-Type": "application/json" ])
                     })
 
                     waitUntil { done in

--- a/HeimdallTests/StubResponseExtensions.swift
+++ b/HeimdallTests/StubResponseExtensions.swift
@@ -1,8 +1,0 @@
-import AeroGearHttpStub
-import Foundation
-
-extension StubResponse {
-    convenience init(filename: String, bundle: NSBundle, statusCode: Int = 200, headers: [String: String] = [ "Content-Type": "application/json" ]) {
-        self.init(filename: filename, location: .Bundle(bundle), statusCode: statusCode, headers: headers)
-    }
-}


### PR DESCRIPTION
Closes #45 

Unfortunately OHHTTPStubs has not released a formal version in a while so I used `master`.