### PR TITLE
Feature/extension grant

### DIFF
--- a/Heimdall/Heimdall.swift
+++ b/Heimdall/Heimdall.swift
@@ -12,7 +12,7 @@ public let HeimdallErrorNotAuthorized = 2
 /// stands on the rainbow bridge network to authorize relevant requests.
 @objc
 public class Heimdall {
-    private let tokenURL: NSURL
+    public let tokenURL: NSURL
     private let credentials: OAuthClientCredentials?
 
     private let accessTokenStore: OAuthAccessTokenStore
@@ -92,6 +92,19 @@ public class Heimdall {
     /// :param: completion A callback to invoke when the request completed.
     public func requestAccessToken(#username: String, password: String, completion: Result<Void, NSError> -> ()) {
         requestAccessToken(grant: .ResourceOwnerPasswordCredentials(username, password)) { result in
+            completion(result.map { _ in return })
+        }
+    }
+    
+    /// Requests an access token with the given grant type URI and parameters
+    ///
+    /// **Note:** The completion closure may be invoked on any thread.
+    ///
+    /// :param: grantType The grant type URI of the extension grant
+    /// :param: parameters The required parameters for the external grant
+    /// :param: completion A callback to invoke when the request completed.
+    public func requestAccessToken(#grantType: String, parameters: [String: String], completion: Result<Void, NSError> -> ()) {
+        requestAccessToken(grant: .Extension(grantType, parameters)) { result in
             completion(result.map { _ in return })
         }
     }

--- a/Heimdall/NSURLRequestExtensions.swift
+++ b/Heimdall/NSURLRequestExtensions.swift
@@ -91,6 +91,7 @@ public extension NSMutableURLRequest {
     
     //Taken from https://github.com/Alamofire/Alamofire/blob/master/Source/ParameterEncoding.swift#L136
     func queryComponents(key: String, _ value: AnyObject) -> [(String, String)] {
+    private func queryComponents(key: String, _ value: AnyObject) -> [(String, String)] {
         var components: [(String, String)] = []
         if let dictionary = value as? [String: AnyObject] {
             for (nestedKey, value) in dictionary {

--- a/Heimdall/NSURLRequestExtensions.swift
+++ b/Heimdall/NSURLRequestExtensions.swift
@@ -80,7 +80,7 @@ public extension NSMutableURLRequest {
         if let parameters = parameters {
             var components: [(String, String)] = []
             for (key, value) in parameters {
-                components += self.queryComponents(key, value)
+                components += queryComponents(key, value)
             }
             var bodyString = join("&", components.map{"\($0)=\($1)"} as [String])
             HTTPBody = bodyString.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)

--- a/Heimdall/NSURLRequestExtensions.swift
+++ b/Heimdall/NSURLRequestExtensions.swift
@@ -79,15 +79,35 @@ public extension NSMutableURLRequest {
     public func setHTTPBody(#parameters: [String: String]?) {
         if let parameters = parameters {
             var parts = [String]()
-            for (name, value) in parameters {
-                let encodedName = name.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding)
-                let encodedValue = value.stringByAddingPercentEscapesUsingEncoding(NSUTF8StringEncoding)
-                parts.append("\(encodedName!)=\(encodedValue!)")
+            for (key, value) in parameters {
+                let encodedKey = percentEscapedQueryStringKey(key)
+                let encodedValue = percentEscapedQueryStringValue(value)
+                parts.append("\(encodedKey)=\(encodedValue)")
             }
-
-            HTTPBody = "&".join(parts).dataUsingEncoding(NSUTF8StringEncoding)
+            
+            var bodyString = "&".join(parts)
+            HTTPBody = bodyString.dataUsingEncoding(NSUTF8StringEncoding)
         } else {
             HTTPBody = nil
         }
     }
+    
+    private func percentEscapedQueryStringKey(string: String) -> String {
+        let allowedCharacters = NSCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
+        let charactersToLeaveUnescaped = NSCharacterSet(charactersInString:"[].")
+        let charactersToEscape = NSCharacterSet(charactersInString:":/?&=;+!@#$()',*")
+        allowedCharacters.formIntersectionWithCharacterSet(charactersToEscape.invertedSet)
+        allowedCharacters.formUnionWithCharacterSet(charactersToLeaveUnescaped)
+        
+        return string.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacters)!
+    }
+    
+    private func percentEscapedQueryStringValue(string: String) -> String {
+        let allowedCharacters = NSCharacterSet.URLQueryAllowedCharacterSet().mutableCopy() as! NSMutableCharacterSet
+        let charactersToEscape = NSCharacterSet(charactersInString:":/?&=;+!@#$()',*")
+        allowedCharacters.formIntersectionWithCharacterSet(charactersToEscape.invertedSet)
+        
+        return string.stringByAddingPercentEncodingWithAllowedCharacters(allowedCharacters)!
+    }
+    
 }

--- a/Heimdall/NSURLRequestExtensions.swift
+++ b/Heimdall/NSURLRequestExtensions.swift
@@ -82,8 +82,8 @@ public extension NSMutableURLRequest {
             for (key, value) in parameters {
                 components += queryComponents(key, value)
             }
-            var bodyString = join("&", components.map{"\($0)=\($1)"} as [String])
-            HTTPBody = bodyString.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false)
+            var bodyString = join("&", components.map { "\($0)=\($1)" } )
+            HTTPBody = bodyString.dataUsingEncoding(NSUTF8StringEncoding)
         } else {
             HTTPBody = nil
         }

--- a/Heimdall/NSURLRequestExtensions.swift
+++ b/Heimdall/NSURLRequestExtensions.swift
@@ -89,8 +89,7 @@ public extension NSMutableURLRequest {
         }
     }
     
-    //Taken from https://github.com/Alamofire/Alamofire/blob/master/Source/ParameterEncoding.swift#L136
-    func queryComponents(key: String, _ value: AnyObject) -> [(String, String)] {
+    // Taken from https://github.com/Alamofire/Alamofire/blob/master/Source/ParameterEncoding.swift#L136
     private func queryComponents(key: String, _ value: AnyObject) -> [(String, String)] {
         var components: [(String, String)] = []
         if let dictionary = value as? [String: AnyObject] {

--- a/Heimdall/OAuthAuthorizationGrant.swift
+++ b/Heimdall/OAuthAuthorizationGrant.swift
@@ -16,8 +16,8 @@ public enum OAuthAuthorizationGrant {
 
     /// An extension grant
     ///
-    /// :param: grantType the grant type URI of the extension grant
-    /// :param: a dictionary of parameters
+    /// :param: grantType The grant type URI of the extension grant
+    /// :param: parameters A dictionary of parameters
     case Extension(String, [String: String])
 
     /// Returns the grant's parameters.

--- a/Heimdall/OAuthAuthorizationGrant.swift
+++ b/Heimdall/OAuthAuthorizationGrant.swift
@@ -14,12 +14,19 @@ public enum OAuthAuthorizationGrant {
     /// :param: refreshToken The refresh token.
     case RefreshToken(String)
 
+    /// An extension grant
+    ///
+    /// :param: grantType the grant type URI of the extension grant
+    /// :param: a dictionary of parameters
+    case Extension(String, [String: String])
+
     /// Returns the grant's parameters.
     ///
     /// Except for `grant_type`, parameters are specific to each grant:
     ///
     /// - `.ResourceOwnerPasswordCredentials`: `username`, `password`
     /// - `.Refresh`: `refresh_token`
+    /// - `.Extension`: `grantType`, `parameters`
     public var parameters: [String: String] {
         switch self {
         case .ResourceOwnerPasswordCredentials(let username, let password):
@@ -33,6 +40,9 @@ public enum OAuthAuthorizationGrant {
                 "grant_type": "refresh_token",
                 "refresh_token": refreshToken
             ]
+        case .Extension(let grantType, var parameters):
+            parameters["grant_type"] = grantType
+            return parameters
         }
     }
 }

--- a/HeimdallTests/HeimdallSpec.swift
+++ b/HeimdallTests/HeimdallSpec.swift
@@ -113,7 +113,7 @@ class HeimdallSpec: QuickSpec {
                 }
 
                 it("sets the access token") {
-                    expect(accessTokenStore.storeAccessTokenCalled).to(beTrue())
+                    expect(heimdall.hasAccessToken).to(beTrue())
                 }
                 
                 it("stores the access token in the token store") {
@@ -299,7 +299,7 @@ class HeimdallSpec: QuickSpec {
                 }
                 
                 it("sets the access token") {
-                    expect(accessTokenStore.storeAccessTokenCalled).to(beTrue())
+                    expect(heimdall.hasAccessToken).to(beTrue())
                 }
                 
                 it("stores the access token in the token store") {

--- a/HeimdallTests/NSURLRequestExtensionsSpec.swift
+++ b/HeimdallTests/NSURLRequestExtensionsSpec.swift
@@ -142,13 +142,21 @@ class NSMutableURLRequestExtensionsSpec: QuickSpec {
             context("when given parameters") {
                 it("sets the body with encoded parameters") {
                     
-                    let parameters = [
+                    let parameters: [String: AnyObject] = [
                         "#key1": "%value1",
                         "#key2": "%value2",
-                        "key3[]": "value3[]",
-                        "key4": ":/?&=;+!@#$()',*",
+                        "key3": "value3[]",
+                        "key4": ":&=;+!@#$()',*",
                         "key5.": "value.5",
-                        "key6": "https://accounts.example.com/oauth/v2/foo/bar"
+                        "key6": "https://accounts.example.com/oauth/v2/foo/bar",
+                        "key7": [
+                            "one",
+                            "two"
+                        ],
+                        "key8": [
+                            "subkeyOne": "one",
+                            "subkeyTwo": "two"
+                        ]
                     ]
                     
                     request.setHTTPBody(parameters: parameters)
@@ -158,10 +166,12 @@ class NSMutableURLRequestExtensionsSpec: QuickSpec {
                     
                     expect(components?[0]).to(equal("%23key1=%25value1"))
                     expect(components?[1]).to(equal("%23key2=%25value2"))
-                    expect(components?[2]).to(equal("key3[]=value3%5B%5D"))
-                    expect(components?[3]).to(equal("key4=%3A%2F%3F%26%3D%3B%2B%21%40%23%24%28%29%27%2C%2A"))
+                    expect(components?[2]).to(equal("key3=value3[]"))
+                    expect(components?[3]).to(equal("key4=%3A%26%3D%3B%2B%21%40%23%24%28%29%27%2C%2A"))
                     expect(components?[4]).to(equal("key5.=value.5"))
-                    expect(components?[5]).to(equal("key6=https%3A%2F%2Faccounts.example.com%2Foauth%2Fv2%2Ffoo%2Fbar"))
+                    expect(components?[5]).to(equal("key6=https%3A//accounts.example.com/oauth/v2/foo/bar"))
+                    expect(components?[6]).to(equal("key7[]=one"))
+                    expect(components?[7]).to(equal("key7[]=two"))
                 }
             }
         }

--- a/HeimdallTests/NSURLRequestExtensionsSpec.swift
+++ b/HeimdallTests/NSURLRequestExtensionsSpec.swift
@@ -140,14 +140,28 @@ class NSMutableURLRequestExtensionsSpec: QuickSpec {
             }
 
             context("when given parameters") {
-                it("sets the body with encoded parameyers") {
-                    request.setHTTPBody(parameters: [ "#key1": "%value1", "#key2": "%value2" ])
+                it("sets the body with encoded parameters") {
+                    
+                    let parameters = [
+                        "#key1": "%value1",
+                        "#key2": "%value2",
+                        "key3[]": "value3[]",
+                        "key4": ":/?&=;+!@#$()',*",
+                        "key5.": "value.5",
+                        "key6": "https://accounts.example.com/oauth/v2/foo/bar"
+                    ]
+                    
+                    request.setHTTPBody(parameters: parameters)
                     
                     var components = NSString(data: request.HTTPBody!, encoding: NSUTF8StringEncoding)?.componentsSeparatedByString("&") as? [String]
                     components = components?.sorted { $0 < $1 }
                     
                     expect(components?[0]).to(equal("%23key1=%25value1"))
                     expect(components?[1]).to(equal("%23key2=%25value2"))
+                    expect(components?[2]).to(equal("key3[]=value3%5B%5D"))
+                    expect(components?[3]).to(equal("key4=%3A%2F%3F%26%3D%3B%2B%21%40%23%24%28%29%27%2C%2A"))
+                    expect(components?[4]).to(equal("key5.=value.5"))
+                    expect(components?[5]).to(equal("key6=https%3A%2F%2Faccounts.example.com%2Foauth%2Fv2%2Ffoo%2Fbar"))
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Heimdall
 
-Heimdall is an [OAuth 2.0](https://tools.ietf.org/html/rfc6749) client specifically designed for easy usage. It currently only supports the [resource owner password credentials grant](https://tools.ietf.org/html/rfc6749#section-4.3) flow as well as [refreshing an access token](https://tools.ietf.org/html/rfc6749#section-6).
+Heimdall is an [OAuth 2.0](https://tools.ietf.org/html/rfc6749) client specifically designed for easy usage. It currently supports the [resource owner password credentials grant](https://tools.ietf.org/html/rfc6749#section-4.3) flow, [refreshing an access token](https://tools.ietf.org/html/rfc6749#section-6) as well as [extension grants](https://tools.ietf.org/html/rfc6749#section-4.5).
 
 If you are familiar with [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa), also check out [ReactiveHeimdall](https://github.com/rheinfabrik/ReactiveHeimdall)!
 

--- a/README.md
+++ b/README.md
@@ -185,3 +185,7 @@ By default, Heimdall authenticates a request by setting the HTTP header field `A
 ## About
 
 Heimdall was built by [Rheinfabrik](http://www.rheinfabrik.de) 🏭
+
+## Credits
+
+Contains code for query string escaping taken from [Alamofire](https://github.com/Alamofire/Alamofire/) (MIT License)


### PR DESCRIPTION
This adds support for extension grants as described in https://tools.ietf.org/html/rfc6749#section-4.5

I changed the percent-encoding of the HTTP body which was not working correctly. I based the new encoding on [AFNetworking's implementation](https://github.com/AFNetworking/AFNetworking/blob/master/AFNetworking/AFURLRequestSerialization.m#L64).