### PR TITLE
Authorization Header is supposed to use the "Bearer" value with a capital B

### DIFF
--- a/Heimdall/NSURLRequestExtensions.swift
+++ b/Heimdall/NSURLRequestExtensions.swift
@@ -27,7 +27,7 @@ public enum HTTPAuthentication: Equatable {
                 return nil
             }
         case .AccessTokenAuthentication(let accessToken):
-            return "\(accessToken.tokenType) \(accessToken.accessToken)"
+            return "\(accessToken.tokenType.capitalizedString) \(accessToken.accessToken)"
         }
     }
 }

--- a/HeimdallTests/HeimdallResourceRequestAuthenticatorHTTPAuthorizationHeaderSpec.swift
+++ b/HeimdallTests/HeimdallResourceRequestAuthenticatorHTTPAuthorizationHeaderSpec.swift
@@ -15,7 +15,7 @@ class HeimdallResourceRequestAuthenticatorHTTPAuthorizationHeaderSpec: QuickSpec
                 let accessToken = OAuthAccessToken(accessToken: "MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ", tokenType: "bearer")
                 let authenticatedRequest = resourceAuthenticator.authenticateResourceRequest(urlRequest, accessToken: accessToken)
                 let authorizationHeaderValue = authenticatedRequest.valueForHTTPHeaderField("Authorization")
-                expect(authorizationHeaderValue).to(equal("bearer MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ"))
+                expect(authorizationHeaderValue).to(equal("Bearer MTQzM2U3YTI3YmQyOWQ5YzQ0NjY4YTZkYjM0MjczYmZhNWI1M2YxM2Y1MjgwYTg3NDk3ZDc4ZGUzM2YxZmJjZQ"))
             }
             
         }


### PR DESCRIPTION
Authorization Header is supposed to use the "Bearer" value with a capital B
[RFC 6750](https://tools.ietf.org/html/rfc675) "The OAuth 2.0 Authorization Framework: Bearer Token Usage", [section 2.1](https://tools.ietf.org/html/rfc6750#section-2.1)