### PR TITLE
Fix decoding without an expiration date

### DIFF
--- a/Heimdall/OAuthAccessToken.swift
+++ b/Heimdall/OAuthAccessToken.swift
@@ -66,9 +66,9 @@ extension OAuthAccessToken: Decodable {
 
     public class func decode(json: JSON) -> Decoded<OAuthAccessToken> {
         func toNSDate(timeIntervalSinceNow: NSTimeInterval?) -> Decoded<NSDate?> {
-            return .fromOptional(map(timeIntervalSinceNow) { timeIntervalSinceNow in
+            return pure(map(timeIntervalSinceNow) { timeIntervalSinceNow in
                 return NSDate(timeIntervalSinceNow: timeIntervalSinceNow)
-            })
+            } ?? .None)
         }
 
         return create

--- a/HeimdallTests/OAuthAccessTokenSpec.swift
+++ b/HeimdallTests/OAuthAccessTokenSpec.swift
@@ -1,3 +1,4 @@
+import Argo
 import Heimdall
 import Nimble
 import Quick
@@ -132,6 +133,23 @@ class OAuthAccessTokenSpec: QuickSpec {
                 let rhs = OAuthAccessToken(accessToken: "accessToken", tokenType: "tokenType", refreshToken: "refreshTokenb")
                 
                 expect(lhs == rhs).to(beFalse())
+            }
+        }
+
+        describe("+decode") {
+            context("without an expiration date") {
+                it("creates a valid access token") {
+                    let accessToken = OAuthAccessToken.decode(.Object([
+                        "access_token": .String("accessToken"),
+                        "token_type": .String("tokenType")
+                    ]))
+
+                    expect(accessToken.value).toNot(beNil())
+                    expect(accessToken.value?.accessToken).to(equal("accessToken"))
+                    expect(accessToken.value?.tokenType).to(equal("tokenType"))
+                    expect(accessToken.value?.expiresAt).to(beNil())
+                    expect(accessToken.value?.refreshToken).to(beNil())
+                }
             }
         }
     }


### PR DESCRIPTION
As reported by @MarvinNazari in #58, there is a bug when an access token without an expiration date is tried to be decoded.