### PR TITLE
Update NSURLRequestExtensions.swift

### DIFF
--- a/Heimdall/NSURLRequestExtensions.swift
+++ b/Heimdall/NSURLRequestExtensions.swift
@@ -108,9 +108,7 @@ public extension NSMutableURLRequest {
     }
 
     private func escapeQuery(string: String) -> String {
-        let legalURLCharactersToBeEscaped: CFStringRef = ":&=;+!@#$()',*"
-        let charactersToLeaveUnescaped: CFStringRef = "[]."
-        return CFURLCreateStringByAddingPercentEscapes(nil, string, charactersToLeaveUnescaped, legalURLCharactersToBeEscaped, CFStringBuiltInEncodings.UTF8.rawValue) as String
+        return string.stringByAddingPercentEncodingWithAllowedCharacters(NSCharacterSet.URLQueryAllowedCharacterSet())!
     }
 
 }


### PR DESCRIPTION
updating the escapeQuery code for iOS 9.0+ as:
CFURLCreateStringByAddingPercentEscapes' is deprecated: first deprecated in iOS 9.0